### PR TITLE
feat: support tailwindcss 3.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,22 +115,6 @@ Result:
 }
 ```
 
-### Outlook (webmail)
-
-Use the `outlook-web` variant to target iOS Mail 15 specifically:
-
-```html
-<div class="outlook-web:hidden">...</div>
-```
-
-Result:
-
-```css
-[class~="x_outlook-web\:hidden"] {
-  display: none;
-}
-```
-
 ### Outlook.com dark mode
 
 Change `color` and `background-color` of elements in [Outlook.com dark mode](https://www.hteumeuleu.com/2021/emails-react-outlook-com-dark-mode/).
@@ -170,40 +154,5 @@ Result:
 ```css
 .ox\:hidden[class^="ox-"] {
   display: none;
-}
-```
-
-## Configuration
-
-You can add your own variants by passing a configuration object to the plugin.
-
-```js
-// tailwind.config.js
-module.exports = {
-  plugins: [
-    require('tailwindcss-email-variants')({
-      thunderbird: '.moz-text-html &', // & is the utility class
-      example: ctx => `.example ${ctx.container.nodes[0].selector}` // using a function
-    }),
-    // ...
-  ],
-}
-```
-
-Use it:
-
-```html
-<div class="thunderbird:hidden example:flex">...</div>
-```
-
-Result:
-
-```css
-.moz-text-html .thunderbird\:hidden {
-  display: none;
-}
-
-.example .flex {
-  display: flex;
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,10 @@
         "np": "^7.6.1",
         "postcss": "^8.2.2",
         "prettier": "^2.5.1",
-        "tailwindcss": "^3.0.24"
+        "tailwindcss": "^3.1.3"
       },
       "peerDependencies": {
-        "tailwindcss": ">=3.0.0"
+        "tailwindcss": ">=3.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -6833,12 +6833,12 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.2.tgz",
-      "integrity": "sha512-yJ6L5s1U5AeS5g7HHy212zdQfjwD426FBfm59pet/JsyneuZuD4C2W7PpJEg4ppisiB21uLqtNagv8KXury3+Q==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.3.tgz",
+      "integrity": "sha512-PRJNYdSIthrb8hjmAyymEyEN8Yo61TMXpzyFUpxULeeyRn3Y3gpvuw6FlRTKrJvK7thSGKRnhT36VovVx4WeMA==",
       "dev": true,
       "dependencies": {
-        "arg": "^5.0.1",
+        "arg": "^5.0.2",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
         "detective": "^5.2.1",
@@ -8373,9 +8373,9 @@
       }
     },
     "arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
     },
     "argparse": {
@@ -12432,12 +12432,12 @@
       "dev": true
     },
     "tailwindcss": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.2.tgz",
-      "integrity": "sha512-yJ6L5s1U5AeS5g7HHy212zdQfjwD426FBfm59pet/JsyneuZuD4C2W7PpJEg4ppisiB21uLqtNagv8KXury3+Q==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.1.3.tgz",
+      "integrity": "sha512-PRJNYdSIthrb8hjmAyymEyEN8Yo61TMXpzyFUpxULeeyRn3Y3gpvuw6FlRTKrJvK7thSGKRnhT36VovVx4WeMA==",
       "dev": true,
       "requires": {
-        "arg": "^5.0.1",
+        "arg": "^5.0.2",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
         "detective": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "np": "^7.6.1",
     "postcss": "^8.2.2",
     "prettier": "^2.5.1",
-    "tailwindcss": "^3.0.24"
+    "tailwindcss": "^3.1.3"
   },
   "peerDependencies": {
-    "tailwindcss": ">=3.0.0"
+    "tailwindcss": ">=3.1.0"
   },
   "prettier": {
     "printWidth": 100,

--- a/src/index.js
+++ b/src/index.js
@@ -25,19 +25,8 @@ const emailClientVariants = plugin.withOptions(
       // iOS Mail 15+
       addVariant('ios-15', '@supports (-webkit-overflow-scrolling:touch) and (aspect-ratio: 1 / 1)')
 
-      // Outlook (webmail)
-      addVariant('outlook-web', ctx => {
-        const foo = get(ctx.container.nodes[0], 'raws.tailwind.classCandidate', '&')
-        return `[class~="x_outlook-web\\:${foo}"]`
-      })
-
       // Open-Xchange (multiple clients)
       addVariant('ox', '&[class^="ox-"]')
-
-      // User-defined variants
-      Object.keys(userVariants).forEach(key => {
-        addVariant(key, userVariants[key])
-      })
     }
   }
 )

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -111,20 +111,6 @@ it('`ios-15` variant', () => {
   })
 })
 
-it('`outlook-web` variant', () => {
-  const config = {
-    content: [{ raw: String.raw`<div class="outlook-web:hidden"></div>` }]
-  }
-
-  return run(config).then((result) => {
-    expect(result.css).toMatchCss(String.raw`
-      [class~="x_outlook-web\:hidden"] {
-        display: none;
-      }
-    `)
-  })
-})
-
 it('`apple-mail` variant', () => {
   const config = {
     content: [{ raw: String.raw`<div class="apple-mail:hidden"></div>` }]
@@ -147,30 +133,6 @@ it('`ox` variant', () => {
   return run(config).then((result) => {
     expect(result.css).toMatchCss(String.raw`
       .ox\:hidden[class^="ox-"] {
-        display: none;
-      }
-    `)
-  })
-})
-
-it('user-defined variants', () => {
-  const config = {
-    content: [{ raw: String.raw`<div class="thunderbird:hidden example:hidden"></div>` }],
-    plugins: [
-      etvPlugin({
-        thunderbird: '.moz-text-html &',
-        example: ctx => `.example ${ctx.container.nodes[0].selector}`
-      })
-    ],
-  }
-
-  return run(config).then((result) => {
-    expect(result.css).toMatchCss(String.raw`
-      .moz-text-html .thunderbird\:hidden {
-        display: none;
-      }
-
-      .example .hidden {
         display: none;
       }
     `)


### PR DESCRIPTION
### Changed

- BREAKING: added support for Tailwind CSS v3.1.x 83747d3
- BREAKING: removed invalid variants b4e68bc

In Tailwind CSS `v3.1.x`, variants that you register need to contain an at-rule or to include the `&` marker, which means we can no longer provide the `outlook-web` variant or support user-defined variants.